### PR TITLE
Strip debug data from binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY zero.go .
 ARG GOOS=linux
 ARG CGO_ENABLED=0
 
-RUN go build -ldflags '-w' -a -o /zero
+RUN go build -ldflags '-s -w' -a -o /zero
 
 FROM scratch
 COPY --from=src /zero /zero


### PR DESCRIPTION
Use -s linker flag to omit the symbol table and debug information.