### PR TITLE
Use asm to create zero binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ fabric.properties
 # Editor-based Rest Client
 .idea/httpRequests
 
+zero
+zero.o

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
-FROM golang as src
+FROM tomasbasham/nasm as builder
 
-COPY zero.go .
-ARG GOOS=linux
-ARG CGO_ENABLED=0
-
-RUN go build -ldflags '-w' -a -o /zero
+WORKDIR /tmp/app
+COPY zero.asm .
+RUN nasm -f bin -o zero zero.asm && chmod +x zero
 
 FROM scratch
-COPY --from=src /zero /zero
+COPY --from=builder /tmp/app/zero zero
 CMD ["/zero"]

--- a/zero.asm
+++ b/zero.asm
@@ -1,0 +1,27 @@
+BITS 32
+
+    org     0x00010000
+
+    db      0x7F, "ELF"             ; e_ident
+    dd      1                                       ; p_type
+    dd      0                                       ; p_offset
+    dd      $$                                      ; p_vaddr
+    dw      2                       ; e_type        ; p_paddr
+    dw      3                       ; e_machine
+    dd      _start                  ; e_version     ; p_filesz
+    dd      _start                  ; e_entry       ; p_memsz
+    dd      4                       ; e_phoff       ; p_flags
+_start:
+    mov     bl, 0                  ; e_shoff       ; p_align
+    xor     eax, eax
+    inc     eax                     ; e_flags
+    int     0x80
+    db      0
+    dw      0x34                    ; e_ehsize
+    dw      0x20                    ; e_phentsize
+    db      1                       ; e_phnum
+                                    ; e_shentsize
+                                    ; e_shnum
+                                    ; e_shstrndx
+
+filesize    equ     $ - $$

--- a/zero.go
+++ b/zero.go
@@ -1,4 +1,0 @@
-package main
-
-func main() {
-}


### PR DESCRIPTION
Using go will create unnecessary bloat image with the size of 826kB. Now that is a huge binary just to return zero so why not write it in asm?

Couple tricks I applied here:

- Write elf header by hand
- Strip parts of elf header that are not used
- Make program table overlap with elf header
- Use nasm to output flat binary
- Insted of setting ebx set bl
- Set eax to 1 by xor and inc

And with these tricks applied the final size of container: **45B**